### PR TITLE
Fix for MSVC. unordered_map is now part of the standard.

### DIFF
--- a/source/block_diag_matrix.h
+++ b/source/block_diag_matrix.h
@@ -2,15 +2,14 @@
 #ifndef _BLOCK_DIAG_MATRIX_H_
 #define _BLOCK_DIAG_MATRIX_H_
 
-#include <tr1/unordered_map>
+#include <unordered_map>
 #include <vector>
 #include <string>
 #include <fstream>
 #include <cassert>
 #include <iostream>
 
-#ifndef DEBUG
-#define DEBUG
+#ifdef DEBUG
 template<class el_type>
 std::ostream& operator<< (std::ostream& os, const std::vector<el_type>& vec)
 {


### PR DESCRIPTION
I also did not understand the purpose of the DEBUG macro. It interfered with other headers and libraries.
