### PR TITLE
OSX build.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,25 +1,36 @@
 CC := g++
-SRCDIR := .
+SRCDIR := $(PWD)
 BUILDDIR := build
-CFLAGS := -O3 -std=gnu++0x
+CFLAGS := -O3 -std=gnu++0x -I$(SRCDIR)/include/gflags
 DEBUG := -w
 TARGET := ldl_driver
 TARBALL := matrix_factor.tar
 OUTPUT := output_matrices/out*
  
-SOURCES := ./ldl_driver.cpp ./include/gflags/*
+VPATH = .:include/gflags
+SOURCES_CPP := $(SRCDIR)/ldl_driver.cpp
+SOURCES_CC := $(wildcard $(SRCDIR)/include/gflags/*.cc)
 
-$(TARGET): 
+%.o: %.cpp
+	$(CC) -c -o $@ $(DEBUG) $(CFLAGS) $<
+
+%.o: %.cc
+	$(CC) -c -o $@ $(DEBUG) $(CFLAGS) $<
+
+$(TARGET): $(SOURCES_CPP:.cpp=.o) $(SOURCES_CC:.cc=.o)
 	@mkdir -p output_matrices
-	@echo " Compiling executable..."; $(CC) $^ $(DEBUG) $(CFLAGS) $(SOURCES) -o $(TARGET)
+	@echo " Compiling executable...";
+	$(CC) -o $@ $(DEBUG) $(CFLAGS) $^
 	@echo " Done.";
 	@echo " Compiling mex files...";
-	@cd matlab_files; make > /dev/null
+	@cd matlab_files; make
 	@echo " Done.";
 	
 .PHONY : clean
 clean:
-	@echo " Cleaning..."; $(RM) -r $(TARGET) $(TARBALL) $(OUTPUT); 
+	@echo " Cleaning...";
+	$(RM) -r $(TARGET) $(TARBALL) $(OUTPUT)
+	$(RM) $(SOURCES_CPP:.cpp=.o) $(SOURCES_CC:.cc=.o)
 
 tar:
 	tar cfv matrix_factor.tar ldl_driver.cpp source

--- a/matlab_files/makefile
+++ b/matlab_files/makefile
@@ -5,16 +5,20 @@ FILES = utils.cpp ../*.cpp ../*.h
 all : ildl.mex*
 
 UNAME := $(shell uname)
-MEX = mex
+MATLABDIR := /Applications/Matlab/MATLAB_R2015b.app
 
 ifeq ($(UNAME), Linux)
-MEX = mex
+MEXNAME = mex
+else ifeq ($(UNAME), Darwin)
+MEXNAME = mex
 else
-MEX = mex.bat
+MEXNAME = mex.bat
 endif
 
-MEXFLAGS =-largeArrayDims
-MEXEXTRA =ildl.cpp utils.cpp
+MEX = $(MATLABDIR)/bin/$(MEXNAME)
+
+MEXFLAGS = -largeArrayDims
+MEXEXTRA = ildl.cpp utils.cpp
 
 %.mex*: %.cpp
 	$(MEX) $(MEXFLAGS) $(MEXEXTRA)


### PR DESCRIPTION
A clang++ build is possible on OSX with these changes. A user should set `MATLABDIR` before invoking `make`. For example,
```
MATLABDIR=/usr/opt/matlab make
```
(on Linux) or
```
MATLABDIR=/Applications/Matlab/MATLAB_R2013b.app
```
(on OSX). On Windows, I'm not so sure.